### PR TITLE
Ignore some parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,20 @@ A better bind feature for automated tests in Laravel/Lumen 5+.
 
 # Why BetterBind is better
 
+1. It's less verbose than Laravel's built-in option.
+2. It protects you against missing constructor parameters.
+3. You can choose to check the constructor parameters for correctness.
+
 Automated testing in Laravel using mocks means injecting objects using the 
-Application's `bind` and `makeWith` methods.
+Application's `bind` method.
 
 This can have some drawbacks.
 
- * It's verbose in Laravel.
- * It doesn't test that the objects are instantiated with the right parameters.
+ * `App::bind` is verbose in Laravel.
+ * `App::bind` doesn't test that the objects are instantiated with the right parameters.
 
-BetterBind provides a syntactically friendly mechanism to verify that the 
-parameters your operational code provides are the parameters that the real 
-target class expects.
+BetterBind provides a syntactically friendly mechanism to verify that 
+constructor parameters match your target class.
 
 Missing parameters cause an assertion failure.
 
@@ -156,6 +159,13 @@ assertions will run against the parameters.
 
 If `$signature` is a string that does not refer to an existing class, no 
 assertions will run against the parameters.
+
+### appBind(...)->ignoreParameters($param1, $param2, ...)
+
+ Do not check that the given parameters name are given by the call to 
+ `makeWith`. Allow Laravel to supply them.
+
+ * $paramN - string, the name of a parameter
 
 # I'm not convinced. Can't I do this without BetterBind?
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ assertions will run against the parameters.
 
 ### betterBind(...)->ignoreParameters($param1, $param2, ...)
 
- Do not check that the given parameters name are given by the call to 
- `makeWith`. Allow Laravel to supply them.
+Allow Laravel to supply the parameters named. Do not check that the given 
+parameter names are given by the call to `makeWith`.
 
  * $paramN - string, the name of a parameter
 

--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ object to do the job. There will be no test failure.
 
 Using BetterBind, the missing value will be detected and the test will fail.
 
-Of course, if you _want_ Laravel to fill in a new `Animal` object itself, you 
-can use `Application`'s original `bind` method.
+If you _want_ Laravel to fill in a new `Animal` object itself, you can add 
+`->ignoreParameters('animal')`.
 
 # Compatibility
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Application's `bind` method.
 This can have some drawbacks.
 
  * `App::bind` is verbose in Laravel.
- * `App::bind` doesn't test that the objects are instantiated with the right parameters.
+ * `App::bind` doesn't test that an object is instantiated with the right parameters.
 
 BetterBind provides a syntactically friendly mechanism to verify that 
 constructor parameters match your target class.

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -15,7 +15,7 @@ trait BetterBind
         App::bind($signature, function ($app, $params) use ($signature, $closure, &$caught_params, $binder) {
             $caught_params = $params;
             if (class_exists($signature)) {
-                $this->assertParamsMatchConstructor($signature, $params, $binder->getIgnoreParameters());
+                $this->assertParamsMatchConstructor($signature, $params, $binder->getIgnoredParameters());
             }
             return $closure($app, $params);
         });

--- a/src/BetterBinder.php
+++ b/src/BetterBinder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ThatsUs;
+
+class BetterBinder
+{
+    private $ignore_parameters = [];
+
+    public function ignoreParameters(array $params = [])
+    {
+        $this->ignore_parameters = $params;
+        return $this;
+    }
+
+    public function getIgnoreParameters()
+    {
+        return $this->ignore_parameters;
+    }
+}

--- a/src/BetterBinder.php
+++ b/src/BetterBinder.php
@@ -6,8 +6,11 @@ class BetterBinder
 {
     private $ignore_parameters = [];
 
-    public function ignoreParameters(array $params = [])
+    public function ignoreParameters(...$params)
     {
+        if (is_array($params[0])) {
+            $params = $params[0];
+        }
         $this->ignore_parameters = $params;
         return $this;
     }

--- a/src/BetterBinder.php
+++ b/src/BetterBinder.php
@@ -4,19 +4,19 @@ namespace ThatsUs;
 
 class BetterBinder
 {
-    private $ignore_parameters = [];
+    private $ignored_parameters = [];
 
     public function ignoreParameters(...$params)
     {
         if (is_array($params[0])) {
             $params = $params[0];
         }
-        $this->ignore_parameters = $params;
+        $this->ignored_parameters = $params;
         return $this;
     }
 
-    public function getIgnoreParameters()
+    public function getIgnoredParameters()
     {
-        return $this->ignore_parameters;
+        return $this->ignored_parameters;
     }
 }

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -144,4 +144,13 @@ class BetterBindTest extends TestCase
         $this->assertEquals($params['y'], 'z');
         $this->assertCount(1, $params);
     }
+
+    public function testIgnoreParameters()
+    {
+        $object = new stdClass();
+        $this->appInstance(INeedParams::class, $object, $params)
+            ->ignoreParameters('first_param');
+        $got = App::makeWith(INeedParams::class, ['second_param' => 456]);
+        $this->assertSame($object, $got);
+    }
 }

--- a/tests/BetterBinderTest.php
+++ b/tests/BetterBinderTest.php
@@ -16,7 +16,7 @@ class BetterBinderTest extends \TestCase
         $results = $binder->ignoreParameters(['x']);
 
         $this->assertSame($binder, $results);
-        $this->assertEquals(['x'], $binder->getIgnoreParameters());
+        $this->assertEquals(['x'], $binder->getIgnoredParameters());
     }
 
     public function testIgnoreParameters_String()
@@ -25,6 +25,6 @@ class BetterBinderTest extends \TestCase
         $results = $binder->ignoreParameters('x');
 
         $this->assertSame($binder, $results);
-        $this->assertEquals(['x'], $binder->getIgnoreParameters());
+        $this->assertEquals(['x'], $binder->getIgnoredParameters());
     }
 }

--- a/tests/BetterBinderTest.php
+++ b/tests/BetterBinderTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ThatsUs;
+
+class BetterBinderTest extends \TestCase
+{
+
+    public function testExists()
+    {
+        new BetterBinder();
+    }
+
+    public function testIgnoreParameters()
+    {
+        $binder = new BetterBinder();
+        $results = $binder->ignoreParameters(['x']);
+
+        $this->assertSame($binder, $results);
+        $this->assertEquals(['x'], $binder->getIgnoreParameters());
+    }
+}

--- a/tests/BetterBinderTest.php
+++ b/tests/BetterBinderTest.php
@@ -10,10 +10,19 @@ class BetterBinderTest extends \TestCase
         new BetterBinder();
     }
 
-    public function testIgnoreParameters()
+    public function testIgnoreParameters_Array()
     {
         $binder = new BetterBinder();
         $results = $binder->ignoreParameters(['x']);
+
+        $this->assertSame($binder, $results);
+        $this->assertEquals(['x'], $binder->getIgnoreParameters());
+    }
+
+    public function testIgnoreParameters_String()
+    {
+        $binder = new BetterBinder();
+        $results = $binder->ignoreParameters('x');
 
         $this->assertSame($binder, $results);
         $this->assertEquals(['x'], $binder->getIgnoreParameters());


### PR DESCRIPTION
Resolves #3 

We are now able to ignore some parameters with the expectation that Laravel's IoC will fill them in.