### PR TITLE
Change method names to better* instead of app*

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class TestCase
 In this example we expect the `Dog::bark` method to create a `Sound` object with 
 itself as the value for the constructor's `$animal` parameter.
 
-First, we use the `appInstance` method from BetterBind to provide the mock to 
+First, we use the `betterInstance` method from BetterBind to provide the mock to 
 the code. Then we capture the `$params` argument and check at the end that it 
 has the parameter values we expect.
 
@@ -56,7 +56,7 @@ class DogTest extends TestCase
         $mock = Mockery::mock(Sound::class);
         $mock->shouldReceive('emit')
             ->once();
-        $this->appInstance(Sound::class, $mock, $params);
+        $this->betterInstance(Sound::class, $mock, $params);
 
         $dog = new Dog();
         $dog->bark();
@@ -130,7 +130,7 @@ Extra parameters provided to class constructor for `Sound`: `volume`
 
 # Methods
 
-### appInstance($signature, $object, [&$params = []])
+### betterInstance($signature, $object, [&$params = []])
 
  * $signature - string, the class name or other string requested in a 
                 `makeWith` call.
@@ -142,7 +142,7 @@ Extra parameters provided to class constructor for `Sound`: `volume`
 If `$signature` is a string that does not refer to an existing class, no 
 assertions will run against the parameters.
 
-### appBind($signature, $closure, [&$params = []])
+### betterBind($signature, $closure, [&$params = []])
 
  * $signature - string, the class name or other string requested in a 
                 `makeWith` call.
@@ -171,7 +171,7 @@ class DogTest extends TestCase
         $mock = Mockery::mock(Sound::class);
         $mock->shouldReceive('emit')
             ->once();
-        $this->appInstance(Sound::class, $mock, $params);
+        $this->betterInstance(Sound::class, $mock, $params);
 
         $dog = new Dog();
         $dog->bark();

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -9,7 +9,7 @@ use Closure;
 trait BetterBind
 {
 
-    public function appBind(string $signature, Closure $closure, &$caught_params = [])
+    public function betterBind(string $signature, Closure $closure, &$caught_params = [])
     {
         App::bind($signature, function ($app, $params) use ($signature, $closure, &$caught_params) {
             $caught_params = $params;
@@ -20,9 +20,9 @@ trait BetterBind
         });
     }
 
-    public function appInstance(string $signature, $instance, &$caught_params = [])
+    public function betterInstance(string $signature, $instance, &$caught_params = [])
     {
-        $this->appBind($signature, function () use ($instance) { return $instance; }, $caught_params);
+        $this->betterBind($signature, function () use ($instance) { return $instance; }, $caught_params);
     }
 
     public function assertParamsMatchConstructor(string $class_name, array $params)

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -13,7 +13,7 @@ class BetterBindTest extends TestCase
     public function testBindNonsenseWordNoParams()
     {
         $object = new stdClass();
-        $this->appBind('x', function () use ($object) { return $object; }, $params);
+        $this->betterBind('x', function () use ($object) { return $object; }, $params);
         $got = App::makeWith('x', []);
         $this->assertEquals($object, $got);
         $this->assertCount(0, $params);
@@ -27,7 +27,7 @@ class BetterBindTest extends TestCase
     public function testBindNonsenseWordAndParams()
     {
         $object = new stdClass();
-        $this->appBind('x', function () use ($object) { return $object; }, $params);
+        $this->betterBind('x', function () use ($object) { return $object; }, $params);
         $got = App::makeWith('x', ['y' => 'z']);
         $this->assertEquals($object, $got);
         $this->assertEquals($params['y'], 'z');
@@ -41,7 +41,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadlessClassNoParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedNoParams::class, []);
         $this->assertEquals($object, $got);
         $this->assertCount(0, $params);
@@ -55,7 +55,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadlessClassWithParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedNoParams::class, ['y' => 'z']);
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -74,7 +74,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithAllParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedParams::class, ['first_param' => 123, 'second_param' => 456]);
         $this->assertEquals($object, $got);
         $this->assertEquals(123, $params['first_param']);
@@ -89,7 +89,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithOneParam()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedParams::class, ['first_param' => 123]);
         $this->assertEquals($object, $got);
         $this->assertEquals(123, $params['first_param']);
@@ -103,7 +103,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassNoParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedParams::class, []);   
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -121,7 +121,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithTooManyParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedParams::class, ['first_param' => 123, 'second_param' => 456, 'failure_param' => 789]);   
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -138,7 +138,7 @@ class BetterBindTest extends TestCase
     public function testInstance()
     {
         $object = new stdClass();
-        $this->appInstance('x', $object, $params);
+        $this->betterInstance('x', $object, $params);
         $got = App::makeWith('x', ['y' => 'z']);
         $this->assertEquals($object, $got);
         $this->assertEquals($params['y'], 'z');


### PR DESCRIPTION
This reduces ambiguity and replaces it with branding!