### PR TITLE
Rename app* methods to test* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class TestCase
 In this example we expect the `Dog::bark` method to create a `Sound` object with 
 itself as the value for the constructor's `$animal` parameter.
 
-First, we use the `appInstance` method from BetterBind to provide the mock to 
+First, we use the `betterInstance` method from BetterBind to provide the mock to 
 the code. Then we capture the `$params` argument and check at the end that it 
 has the parameter values we expect.
 
@@ -56,7 +56,7 @@ class DogTest extends TestCase
         $mock = Mockery::mock(Sound::class);
         $mock->shouldReceive('emit')
             ->once();
-        $this->appInstance(Sound::class, $mock, $params);
+        $this->betterInstance(Sound::class, $mock, $params);
 
         $dog = new Dog();
         $dog->bark();
@@ -130,7 +130,7 @@ Extra parameters provided to class constructor for `Sound`: `volume`
 
 # Methods
 
-### appInstance($signature, $object, [&$params = []])
+### betterInstance($signature, $object, [&$params = []])
 
  * $signature - string, the class name or other string requested in a 
                 `makeWith` call.
@@ -142,7 +142,7 @@ Extra parameters provided to class constructor for `Sound`: `volume`
 If `$signature` is a string that does not refer to an existing class, no 
 assertions will run against the parameters.
 
-### appBind($signature, $closure, [&$params = []])
+### betterBind($signature, $closure, [&$params = []])
 
  * $signature - string, the class name or other string requested in a 
                 `makeWith` call.
@@ -171,7 +171,7 @@ class DogTest extends TestCase
         $mock = Mockery::mock(Sound::class);
         $mock->shouldReceive('emit')
             ->once();
-        $this->appInstance(Sound::class, $mock, $params);
+        $this->betterInstance(Sound::class, $mock, $params);
 
         $dog = new Dog();
         $dog->bark();

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # laravel-better-bind
-A better bind feature for automated tests in Laravel/Lumen 5+.
+A mock binding feature for automated tests in Laravel/Lumen 5+.
 
-# Why testBind is better
+# Why Laravel Better Bind is better
 
 Automated testing in Laravel using mocks means injecting objects using the 
 Application's `bind` and `makeWith` methods.
@@ -157,7 +157,7 @@ assertions will run against the parameters.
 If `$signature` is a string that does not refer to an existing class, no 
 assertions will run against the parameters.
 
-# I'm not convinced. Can't I do this without testBind?
+# I'm not convinced. Can't I do this without Laravel Better Bind?
 
 You can do some of the same stuff without this library.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # laravel-better-bind
 A better bind feature for automated tests in Laravel/Lumen 5+.
 
-# Why BetterBind is better
+# Why testBind is better
 
 Automated testing in Laravel using mocks means injecting objects using the 
 Application's `bind` and `makeWith` methods.
@@ -11,7 +11,7 @@ This can have some drawbacks.
  * It's verbose in Laravel.
  * It doesn't test that the objects are instantiated with the right parameters.
 
-BetterBind provides a syntactically friendly mechanism to verify that the 
+testBind provides a syntactically friendly mechanism to verify that the 
 parameters your operational code provides are the parameters that the real 
 target class expects.
 
@@ -21,7 +21,7 @@ Extra parameters cause an assertion failure.
 
 It can be a one-liner.
 
-BetterBind also provides a way to capture the constructor parameters so you 
+testBind also provides a way to capture the constructor parameters so you 
 can run your own assertions on them.
 
 # Installation
@@ -33,7 +33,7 @@ composer require thatsus/laravel-better-bind
 ```php
 class TestCase
 {
-    use \ThatsUs\BetterBind;
+    use \ThatsUs\testBind;
 
     ...
 }
@@ -44,7 +44,7 @@ class TestCase
 In this example we expect the `Dog::bark` method to create a `Sound` object with 
 itself as the value for the constructor's `$animal` parameter.
 
-First, we use the `betterInstance` method from BetterBind to provide the mock to 
+First, we use the `testInstance` method from testBind to provide the mock to 
 the code. Then we capture the `$params` argument and check at the end that it 
 has the parameter values we expect.
 
@@ -56,7 +56,7 @@ class DogTest extends TestCase
         $mock = Mockery::mock(Sound::class);
         $mock->shouldReceive('emit')
             ->once();
-        $this->betterInstance(Sound::class, $mock, $params);
+        $this->testInstance(Sound::class, $mock, $params);
 
         $dog = new Dog();
         $dog->bark();
@@ -130,7 +130,7 @@ Extra parameters provided to class constructor for `Sound`: `volume`
 
 # Methods
 
-### betterInstance($signature, $object, [&$params = []])
+### testInstance($signature, $object, [&$params = []])
 
  * $signature - string, the class name or other string requested in a 
                 `makeWith` call.
@@ -142,7 +142,7 @@ Extra parameters provided to class constructor for `Sound`: `volume`
 If `$signature` is a string that does not refer to an existing class, no 
 assertions will run against the parameters.
 
-### betterBind($signature, $closure, [&$params = []])
+### testBind($signature, $closure, [&$params = []])
 
  * $signature - string, the class name or other string requested in a 
                 `makeWith` call.
@@ -157,7 +157,7 @@ assertions will run against the parameters.
 If `$signature` is a string that does not refer to an existing class, no 
 assertions will run against the parameters.
 
-# I'm not convinced. Can't I do this without BetterBind?
+# I'm not convinced. Can't I do this without testBind?
 
 You can do some of the same stuff without this library.
 
@@ -171,7 +171,7 @@ class DogTest extends TestCase
         $mock = Mockery::mock(Sound::class);
         $mock->shouldReceive('emit')
             ->once();
-        $this->betterInstance(Sound::class, $mock, $params);
+        $this->testInstance(Sound::class, $mock, $params);
 
         $dog = new Dog();
         $dog->bark();
@@ -202,7 +202,7 @@ class DogTest extends TestCase
 }
 ```
 
-The obvious drawback to the version that doesn't use BetterBind is that there 
+The obvious drawback to the version that doesn't use testBind is that there 
 are extra lines, and one of them is very verbose. The secret extra drawback 
 here is that nothing tests to ensure that the requirements to the real `Sound` 
 class's constructor are met.
@@ -223,7 +223,7 @@ Laravel will detect that `Sound`'s constructor typehints an `Animal` object.
 But no 'animal' element is in the params, so Laravel will new up an `Animal` 
 object to do the job. There will be no test failure.
 
-Using BetterBind, the missing value will be detected and the test will fail.
+Using testBind, the missing value will be detected and the test will fail.
 
 Of course, if you _want_ Laravel to fill in a new `Animal` object itself, you 
 can use `Application`'s original `bind` method.

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -9,7 +9,7 @@ use Closure;
 trait BetterBind
 {
 
-    public function appBind(string $signature, Closure $closure, &$caught_params = [])
+    public function betterBind(string $signature, Closure $closure, &$caught_params = [])
     {
         App::bind($signature, function ($app, $params) use ($signature, $closure, &$caught_params) {
             $caught_params = $params;
@@ -20,9 +20,9 @@ trait BetterBind
         });
     }
 
-    public function appInstance(string $signature, $instance, &$caught_params = [])
+    public function betterInstance(string $signature, $instance, &$caught_params = [])
     {
-        $this->appBind($signature, function () use ($instance) { return $instance; }, $caught_params);
+        $this->betterBind($signature, function () use ($instance) { return $instance; }, $caught_params);
     }
 
     public function assertParamsMatchConstructor(string $class_name, array $params)

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -6,10 +6,10 @@ use Illuminate\Support\Facades\App;
 use ReflectionClass;
 use Closure;
 
-trait BetterBind
+trait testBind
 {
 
-    public function betterBind(string $signature, Closure $closure, &$caught_params = [])
+    public function testBind(string $signature, Closure $closure, &$caught_params = [])
     {
         App::bind($signature, function ($app, $params) use ($signature, $closure, &$caught_params) {
             $caught_params = $params;
@@ -20,9 +20,9 @@ trait BetterBind
         });
     }
 
-    public function betterInstance(string $signature, $instance, &$caught_params = [])
+    public function testInstance(string $signature, $instance, &$caught_params = [])
     {
-        $this->betterBind($signature, function () use ($instance) { return $instance; }, $caught_params);
+        $this->testBind($signature, function () use ($instance) { return $instance; }, $caught_params);
     }
 
     public function assertParamsMatchConstructor(string $class_name, array $params)

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -1,9 +1,9 @@
 <?php
 
-class BetterBindTest extends TestCase
+class testBindTest extends TestCase
 {
 
-    use \ThatsUs\BetterBind;
+    use \ThatsUs\testBind;
 
     /**
      * A non-class-name is used for the signature, so we don't expect any 
@@ -13,7 +13,7 @@ class BetterBindTest extends TestCase
     public function testBindNonsenseWordNoParams()
     {
         $object = new stdClass();
-        $this->betterBind('x', function () use ($object) { return $object; }, $params);
+        $this->testBind('x', function () use ($object) { return $object; }, $params);
         $got = App::makeWith('x', []);
         $this->assertEquals($object, $got);
         $this->assertCount(0, $params);
@@ -27,7 +27,7 @@ class BetterBindTest extends TestCase
     public function testBindNonsenseWordAndParams()
     {
         $object = new stdClass();
-        $this->betterBind('x', function () use ($object) { return $object; }, $params);
+        $this->testBind('x', function () use ($object) { return $object; }, $params);
         $got = App::makeWith('x', ['y' => 'z']);
         $this->assertEquals($object, $got);
         $this->assertEquals($params['y'], 'z');
@@ -41,7 +41,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadlessClassNoParams()
     {
         $object = new stdClass();
-        $this->betterBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
+        $this->testBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedNoParams::class, []);
         $this->assertEquals($object, $got);
         $this->assertCount(0, $params);
@@ -55,7 +55,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadlessClassWithParams()
     {
         $object = new stdClass();
-        $this->betterBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
+        $this->testBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedNoParams::class, ['y' => 'z']);
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -74,7 +74,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithAllParams()
     {
         $object = new stdClass();
-        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->testBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedParams::class, ['first_param' => 123, 'second_param' => 456]);
         $this->assertEquals($object, $got);
         $this->assertEquals(123, $params['first_param']);
@@ -89,7 +89,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithOneParam()
     {
         $object = new stdClass();
-        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->testBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedParams::class, ['first_param' => 123]);
         $this->assertEquals($object, $got);
         $this->assertEquals(123, $params['first_param']);
@@ -103,7 +103,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassNoParams()
     {
         $object = new stdClass();
-        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->testBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedParams::class, []);   
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -121,7 +121,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithTooManyParams()
     {
         $object = new stdClass();
-        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->testBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedParams::class, ['first_param' => 123, 'second_param' => 456, 'failure_param' => 789]);   
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -138,7 +138,7 @@ class BetterBindTest extends TestCase
     public function testInstance()
     {
         $object = new stdClass();
-        $this->betterInstance('x', $object, $params);
+        $this->testInstance('x', $object, $params);
         $got = App::makeWith('x', ['y' => 'z']);
         $this->assertEquals($object, $got);
         $this->assertEquals($params['y'], 'z');

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -13,7 +13,7 @@ class BetterBindTest extends TestCase
     public function testBindNonsenseWordNoParams()
     {
         $object = new stdClass();
-        $this->appBind('x', function () use ($object) { return $object; }, $params);
+        $this->betterBind('x', function () use ($object) { return $object; }, $params);
         $got = App::makeWith('x', []);
         $this->assertEquals($object, $got);
         $this->assertCount(0, $params);
@@ -27,7 +27,7 @@ class BetterBindTest extends TestCase
     public function testBindNonsenseWordAndParams()
     {
         $object = new stdClass();
-        $this->appBind('x', function () use ($object) { return $object; }, $params);
+        $this->betterBind('x', function () use ($object) { return $object; }, $params);
         $got = App::makeWith('x', ['y' => 'z']);
         $this->assertEquals($object, $got);
         $this->assertEquals($params['y'], 'z');
@@ -41,7 +41,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadlessClassNoParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedNoParams::class, []);
         $this->assertEquals($object, $got);
         $this->assertCount(0, $params);
@@ -55,7 +55,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadlessClassWithParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedNoParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedNoParams::class, ['y' => 'z']);
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -74,7 +74,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithAllParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedParams::class, ['first_param' => 123, 'second_param' => 456]);
         $this->assertEquals($object, $got);
         $this->assertEquals(123, $params['first_param']);
@@ -89,7 +89,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithOneParam()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         $got = App::makeWith(INeedParams::class, ['first_param' => 123]);
         $this->assertEquals($object, $got);
         $this->assertEquals(123, $params['first_param']);
@@ -103,7 +103,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassNoParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedParams::class, []);   
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -121,7 +121,7 @@ class BetterBindTest extends TestCase
     public function testBindHeadfulClassWithTooManyParams()
     {
         $object = new stdClass();
-        $this->appBind(INeedParams::class, function () use ($object) { return $object; }, $params);
+        $this->betterBind(INeedParams::class, function () use ($object) { return $object; }, $params);
         try {
             App::makeWith(INeedParams::class, ['first_param' => 123, 'second_param' => 456, 'failure_param' => 789]);   
         } catch (PHPUnit_Framework_ExpectationFailedException $e) {
@@ -138,7 +138,7 @@ class BetterBindTest extends TestCase
     public function testInstance()
     {
         $object = new stdClass();
-        $this->appInstance('x', $object, $params);
+        $this->betterInstance('x', $object, $params);
         $got = App::makeWith('x', ['y' => 'z']);
         $this->assertEquals($object, $got);
         $this->assertEquals($params['y'], 'z');


### PR DESCRIPTION
This reduces ambiguity with App::* methods and it reminds users that this stuff is meant for testing.