### PR TITLE
Check typehints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # laravel-better-bind
 A better bind feature for automated tests in Laravel/Lumen 5+.
 
-# Why BetterBind is better
+# Why Better Bind is better
 
 1. It's less verbose than Laravel's built-in option.
 2. It protects you against missing constructor parameters.
@@ -15,16 +15,18 @@ This can have some drawbacks.
  * `App::bind` is verbose in Laravel.
  * `App::bind` doesn't test that an object is instantiated with the right parameters.
 
-BetterBind provides a syntactically friendly mechanism to verify that 
+Better Bind provides a syntactically friendly mechanism to verify that 
 constructor parameters match your target class.
 
-Missing parameters cause an assertion failure.
+Missing required parameters cause an assertion failure.
 
 Extra parameters cause an assertion failure.
 
+Wrong-type parameters cause an assertion failure.
+
 It can be a one-liner.
 
-BetterBind also provides a way to capture the constructor parameters so you 
+Better Bind also provides a way to capture the constructor parameters so you 
 can run your own assertions on them.
 
 # Installation
@@ -36,7 +38,7 @@ composer require thatsus/laravel-better-bind
 ```php
 class TestCase
 {
-    use \ThatsUs\BetterBind;
+    use \ThatsUs\Better Bind;
 
     ...
 }
@@ -47,7 +49,7 @@ class TestCase
 In this example we expect the `Dog::bark` method to create a `Sound` object with 
 itself as the value for the constructor's `$animal` parameter.
 
-First, we use the `betterInstance` method from BetterBind to provide the mock to 
+First, we use the `betterInstance` method from Better Bind to provide the mock to 
 the code. Then we capture the `$params` argument and check at the end that it 
 has the parameter values we expect.
 
@@ -131,6 +133,25 @@ class Dog
 Extra parameters provided to class constructor for `Sound`: `volume`
 ```
 
+## Failing Code 3
+
+Goofus accidentally passed in a string. That's the wrong type for the `$animal` parameter.
+
+```php
+class Dog
+{
+    public function bark()
+    {
+        App::makeWith(Sound::class, ['animal' => 'this'])->emit();
+    }
+}
+```
+
+```
+1) DogTest::testBark
+Required parameter `animal` for `Sound` is a `string`, but a `Animal` is expected.
+```
+
 # Methods
 
 ### betterInstance($signature, $object, [&$params = []])
@@ -167,7 +188,7 @@ parameter names are given by the call to `makeWith`.
 
  * $paramN - string, the name of a parameter
 
-# I'm not convinced. Can't I do this without BetterBind?
+# I'm not convinced. Can't I do this without Better Bind?
 
 You can do some of the same stuff without this library.
 
@@ -212,7 +233,7 @@ class DogTest extends TestCase
 }
 ```
 
-The obvious drawback to the version that doesn't use BetterBind is that there 
+The obvious drawback to the version that doesn't use Better Bind is that there 
 are extra lines, and one of them is very verbose. The secret extra drawback 
 here is that nothing tests to ensure that the requirements to the real `Sound` 
 class's constructor are met.
@@ -233,7 +254,7 @@ Laravel will detect that `Sound`'s constructor typehints an `Animal` object.
 But no 'animal' element is in the params, so Laravel will new up an `Animal` 
 object to do the job. There will be no test failure.
 
-Using BetterBind, the missing value will be detected and the test will fail.
+Using Better Bind, the missing value will be detected and the test will fail.
 
 If you _want_ Laravel to fill in a new `Animal` object itself, you can add 
 `->ignoreParameters('animal')`.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ composer require thatsus/laravel-better-bind
 ```php
 class TestCase
 {
-    use \ThatsUs\Better Bind;
+    use \ThatsUs\BetterBind;
 
     ...
 }

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -39,6 +39,15 @@ trait BetterBind
                     $name = $parameter->getName();
                     if (!$parameter->isOptional() && !in_array($name, $ignore_params)) {
                         $this->assertTrue(isset($params[$name]), "Required parameter `{$name}` not provided to class constructor for `{$class_name}`");
+                        if ($parameter->getType()) {
+                            $real_type = gettype($params[$name]);
+                            if ($real_type === 'object') {
+                                $real_class = $real_type === 'object' ? get_class($params[$name]) : null;
+                                $this->assertInstanceOf($parameter->getType()->__toString(), $params[$name], "Required parameter `{$name}` for `{$class_name}` is a " . $real_class . ", but a " . $parameter->getType() . " is expected.");
+                            } else {
+                                $this->assertEquals($parameter->getType()->__toString(), $real_type, "Required parameter `{$name}` for `{$class_name}` is a " . $real_type . ", but a " . $parameter->getType() . " is expected.");
+                            }
+                        }
                     }
                     unset($params[$name]);
                 });

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -73,6 +73,12 @@ trait BetterBind
             if (is_string($param) && $type_name == 'bool') {
                 return;
             }
+            if (is_bool($param) && in_array($type_name, ['int', 'float', 'string'])) {
+                return;
+            }
+            if (is_object($param) && $type_name == 'string' && method_exists($param, '__toString')) {
+                return;
+            }
             $this->assertInternalType($type_name, $param, $msg);
         } elseif ($type_name == 'self') {
             $this->assertInstanceOf($self_class, $param, $msg);

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -66,24 +66,29 @@ trait BetterBind
         }
         $type_name = $parameter->getType()->__toString();
         if ($parameter->getType()->isBuiltIn()) {
-            // Each of the following `if` clauses allows for type coercion
-            if (is_numeric($value) && in_array($type_name, ['bool', 'float', 'int', 'string'])) {
-                return;
-            }
-            if (is_string($value) && $type_name == 'bool') {
-                return;
-            }
-            if (is_bool($value) && in_array($type_name, ['int', 'float', 'string'])) {
-                return;
-            }
-            if (is_object($value) && $type_name == 'string' && method_exists($value, '__toString')) {
-                return;
-            }
-            $this->assertInternalType($type_name, $value, $msg);
+            $this->assertInternalTypeCast($type_name, $value, $msg);
         } elseif ($type_name == 'self') {
             $this->assertInstanceOf($self_class, $value, $msg);
         } else {
             $this->assertInstanceOf($type_name, $value, $msg);
         }
+    }
+
+    public function assertInternalTypeCast($type_name, $value, $msg)
+    {
+        // Each of the following `if` clauses allows for type coercion
+        if (is_numeric($value) && in_array($type_name, ['bool', 'float', 'int', 'string'])) {
+            return;
+        }
+        if (is_string($value) && $type_name == 'bool') {
+            return;
+        }
+        if (is_bool($value) && in_array($type_name, ['int', 'float', 'string'])) {
+            return;
+        }
+        if (is_object($value) && $type_name == 'string' && method_exists($value, '__toString')) {
+            return;
+        }
+        $this->assertInternalType($type_name, $value, $msg);
     }
 }

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -66,8 +66,11 @@ trait BetterBind
         }
         $type_name = $parameter->getType()->__toString();
         if ($parameter->getType()->isBuiltIn()) {
-            // These types can coerce from any numeric type
+            // Each of the following `if` clauses allows for type coercion
             if (is_numeric($param) && in_array($type_name, ['bool', 'float', 'int', 'string'])) {
+                return;
+            }
+            if (is_string($param) && $type_name == 'bool') {
                 return;
             }
             $this->assertInternalType($type_name, $param, $msg);

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -38,15 +38,16 @@ trait BetterBind
                 ->each(function ($parameter) use (&$params, $class_name, $ignore_params) {
                     $name = $parameter->getName();
                     if (!$parameter->isOptional() && !in_array($name, $ignore_params)) {
-                        $this->assertTrue(isset($params[$name]), "Required parameter `{$name}` not provided to class constructor for `{$class_name}`");
-                        if ($parameter->getType()) {
-                            $real_type = gettype($params[$name]);
-                            if ($real_type === 'object') {
-                                $real_class = $real_type === 'object' ? get_class($params[$name]) : null;
-                                $this->assertInstanceOf($parameter->getType()->__toString(), $params[$name], "Required parameter `{$name}` for `{$class_name}` is a " . $real_class . ", but a " . $parameter->getType() . " is expected.");
-                            } else {
-                                $this->assertEquals($parameter->getType()->__toString(), $real_type, "Required parameter `{$name}` for `{$class_name}` is a " . $real_type . ", but a " . $parameter->getType() . " is expected.");
-                            }
+                        $this->assertTrue(isset($params[$name]), "Required parameter `{$name}` not provided to class constructor for `{$class_name}`.");
+                    }
+                    if ($parameter->getType() && isset($params[$name])) {
+                        $real_type = gettype($params[$name]);
+                        if ($real_type === 'object') {
+                            $real_class = $real_type === 'object' ? get_class($params[$name]) : null;
+                            $this->assertFalse($parameter->getType()->isBuiltIn(), "Parameter `{$name}` for `{$class_name}` is a `" . $real_class . "`, but a `" . $parameter->getType() . "` is expected.");
+                            $this->assertInstanceOf($parameter->getType()->__toString(), $params[$name], "Parameter `{$name}` for `{$class_name}` is a `" . $real_class . "`, but a `" . $parameter->getType() . "` is expected.");
+                        } else {
+                            $this->assertEquals($parameter->getType()->__toString(), $real_type, "Parameter `{$name}` for `{$class_name}` is a `" . $real_type . "`, but a `" . $parameter->getType() . "` is expected.");
                         }
                     }
                     unset($params[$name]);

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -44,8 +44,9 @@ trait BetterBind
                         $real_type = gettype($params[$name]);
                         if ($real_type === 'object') {
                             $real_class = $real_type === 'object' ? get_class($params[$name]) : null;
-                            $this->assertFalse($parameter->getType()->isBuiltIn(), "Parameter `{$name}` for `{$class_name}` is a `" . $real_class . "`, but a `" . $parameter->getType() . "` is expected.");
-                            $this->assertInstanceOf($parameter->getType()->__toString(), $params[$name], "Parameter `{$name}` for `{$class_name}` is a `" . $real_class . "`, but a `" . $parameter->getType() . "` is expected.");
+                            $msg = "Parameter `{$name}` for `{$class_name}` is a `" . $real_class . "`, but a `" . $parameter->getType() . "` is expected.";
+                            $this->assertFalse($parameter->getType()->isBuiltIn(), $msg);
+                            $this->assertInstanceOf($parameter->getType()->__toString(), $params[$name], $msg);
                         } else {
                             $this->assertEquals($parameter->getType()->__toString(), $real_type, "Parameter `{$name}` for `{$class_name}` is a `" . $real_type . "`, but a `" . $parameter->getType() . "` is expected.");
                         }

--- a/src/BetterBind.php
+++ b/src/BetterBind.php
@@ -45,7 +45,7 @@ trait BetterBind
                         $real_type = gettype($params[$name]);
                         $real_class = $real_type == 'object' ? get_class($params[$name]) : null;
                         $msg = "Constructor parameter `{$name}` for `{$class_name}` is a `" . ($real_class ?: $real_type) . "`, but a `" . $parameter->getType() . "` is expected.";
-                        $this->assertParameterTypeMatchesRealParameter($parameter, $class_name, $params[$name], $msg);
+                        $this->assertParameterTypeMatchesValue($parameter, $class_name, $params[$name], $msg);
                     }
                     unset($params[$name]);
                 });
@@ -59,7 +59,7 @@ trait BetterBind
         }
     }
 
-    public function assertParameterTypeMatchesRealParameter(ReflectionParameter $parameter, string $self_class, $param, string $msg)
+    public function assertParameterTypeMatchesValue(ReflectionParameter $parameter, string $self_class, $value, string $msg)
     {
         if (!$parameter->getType()) {
             return;
@@ -67,23 +67,23 @@ trait BetterBind
         $type_name = $parameter->getType()->__toString();
         if ($parameter->getType()->isBuiltIn()) {
             // Each of the following `if` clauses allows for type coercion
-            if (is_numeric($param) && in_array($type_name, ['bool', 'float', 'int', 'string'])) {
+            if (is_numeric($value) && in_array($type_name, ['bool', 'float', 'int', 'string'])) {
                 return;
             }
-            if (is_string($param) && $type_name == 'bool') {
+            if (is_string($value) && $type_name == 'bool') {
                 return;
             }
-            if (is_bool($param) && in_array($type_name, ['int', 'float', 'string'])) {
+            if (is_bool($value) && in_array($type_name, ['int', 'float', 'string'])) {
                 return;
             }
-            if (is_object($param) && $type_name == 'string' && method_exists($param, '__toString')) {
+            if (is_object($value) && $type_name == 'string' && method_exists($value, '__toString')) {
                 return;
             }
-            $this->assertInternalType($type_name, $param, $msg);
+            $this->assertInternalType($type_name, $value, $msg);
         } elseif ($type_name == 'self') {
-            $this->assertInstanceOf($self_class, $param, $msg);
+            $this->assertInstanceOf($self_class, $value, $msg);
         } else {
-            $this->assertInstanceOf($type_name, $param, $msg);
+            $this->assertInstanceOf($type_name, $value, $msg);
         }
     }
 }

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -306,7 +306,7 @@ class BetterBindTest extends TestCase
             'potato',
             '0.0',
             '0',
-        ];      
+        ];
         $fields = [
             'my_stdClass' => function ($made) {
                 $this->assertInstanceOf(stdClass::class, $made->my_stdClass);
@@ -332,6 +332,13 @@ class BetterBindTest extends TestCase
             'my_string' => function ($made) {
                 $this->assertTrue(is_string($made->my_string));
             },
+            /**
+             * We only have PHP 7.0 to test with right now.
+             * 
+             * 7.1 introduces `iterable`
+             * 7.2 introduces `object`.
+             * http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
+             */
         ];
         // Convert into array of [$field, $assertions, $single_value]
         return collect($fields)

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -285,7 +285,7 @@ class BetterBindTest extends TestCase
             if (!is_object($value) && !is_array($value)) {
                 $description .= " ({$value})";
             }
-            $this->fail("`{$field}` has different behavior for Laravel/PHP and BetterBind {$description}\n"
+            $this->fail("Laravel and BetterBind have different behavior for `{$field}` => {$description}\n"
                 . "Laravel's message: "  . ($laravels_exception ? $laravels_exception->getMessage() : 'No error') . "\n"
                 . "BetterBind's message: "  . ($better_binds_exception ? $better_binds_exception->getMessage() : 'No error') . "\n"
             );
@@ -295,8 +295,7 @@ class BetterBindTest extends TestCase
     public function thingsThatShouldCast()
     {
         $values = [
-            Mockery::mock(stdClass::class),
-            Mockery::mock(INeedParamsWithAllTheTypes::class),
+            new SubclassOfINeedParamsWithAllTheTypes(),
             [],
             [new Exception(), 'getMessage'],
             true,

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -170,7 +170,7 @@ class BetterBindTest extends TestCase
         $this->assertEquals('some string', $params['second_param']);
     }
 
-    public function testTypehintsFail()
+    public function testTypehintsFailRequired()
     {
         $object = new stdClass();
         $this->betterInstance(INeedParamsWithTypes::class, $object, $params);
@@ -188,7 +188,33 @@ class BetterBindTest extends TestCase
         $this->assertRegExp('/stdClass/', $e->getMessage());
         $this->assertRegExp('/string/', $e->getMessage());
         $this->assertNotRegExp('/second_param/', $e->getMessage());
+        $this->assertNotRegExp('/third_param/', $e->getMessage());
         $this->assertEquals('oh no', $params['first_param']);
         $this->assertEquals('some string', $params['second_param']);
+    }
+
+    public function testTypehintsFailOptional()
+    {
+        $object = new stdClass();
+        $this->betterInstance(INeedParamsWithTypes::class, $object, $params);
+        $e = null;
+        try {
+            App::makeWith(INeedParamsWithTypes::class, [
+                'first_param' => new stdClass(),
+                'second_param' => 'some string',
+                'third_param' => new stdClass(),
+            ]);
+        } catch (PHPUnit_Framework_ExpectationFailedException $e) {
+        }
+        $this->assertNotNull($e);
+        $this->assertRegExp('/INeedParamsWithTypes/', $e->getMessage());
+        $this->assertRegExp('/third_param/', $e->getMessage());
+        $this->assertRegExp('/stdClass/', $e->getMessage());
+        $this->assertRegExp('/string/', $e->getMessage());
+        $this->assertNotRegExp('/first_param/', $e->getMessage());
+        $this->assertNotRegExp('/second_param/', $e->getMessage());
+        $this->assertInstanceOf(stdClass::class, $params['first_param']);
+        $this->assertEquals('some string', $params['second_param']);
+        $this->assertInstanceOf(stdClass::class, $params['third_param']);
     }
 }

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -310,25 +310,25 @@ class BetterBindTest extends TestCase
             'my_stdClass' => function ($made) {
                 $this->assertInstanceOf(stdClass::class, $made->my_stdClass);
             },
-            'my_self' => function ($made) {
+            'my_self'     => function ($made) {
                 $this->assertInstanceOf(INeedParamsWithAllTheTypes::class, $made->my_self);
             },
-            'my_array' => function ($made) {
+            'my_array'    => function ($made) {
                 $this->assertTrue(is_array($made->my_array));
             },
             'my_callable' => function ($made) {
                 $this->assertTrue(is_callable($made->my_callable));
             },
-            'my_bool' => function ($made) {
+            'my_bool'     => function ($made) {
                 $this->assertTrue(is_bool($made->my_bool));
             },
-            'my_float' => function ($made) {
+            'my_float'    => function ($made) {
                 $this->assertTrue(is_numeric($made->my_float));
             },
-            'my_int' => function ($made) {
+            'my_int'      => function ($made) {
                 $this->assertTrue(is_numeric($made->my_int));
             },
-            'my_string' => function ($made) {
+            'my_string'   => function ($made) {
                 $this->assertTrue(is_string($made->my_string));
             },
             /**

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -271,7 +271,7 @@ class BetterBindTest extends TestCase
             $got = App::makeWith(INeedParamsWithAllTheTypes::class, $sending_params);
             $this->assertEquals($object, $got);
             $this->assertEquals($sending_params, $params);
-        } catch (\Throwable $e) {
+        } catch (\PHPUnit_Framework_ExpectationFailedException $e) {
             $better_binds_exception = $e;
         }
 

--- a/tests/BetterBindTest.php
+++ b/tests/BetterBindTest.php
@@ -238,6 +238,11 @@ class BetterBindTest extends TestCase
     }
 
     /**
+     * Here we go all out.
+     * We attempt to put every type value into every type parameter.
+     * If Laravel fails then Better Bind needs to fail too. If one succeeds,
+     * then they need to both succeed.
+     * 
      * @dataProvider thingsThatShouldCast
      */
     public function testTypehintsAllTypesCasts($field, $assertions, $value)

--- a/tests/fixtures/INeedParams.php
+++ b/tests/fixtures/INeedParams.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class INeedParams
 {
     public function __construct($first_param, $second_param = 'default')

--- a/tests/fixtures/INeedParamsWithAllTheTypes.php
+++ b/tests/fixtures/INeedParamsWithAllTheTypes.php
@@ -1,0 +1,39 @@
+<?php
+
+
+class INeedParamsWithAllTheTypes
+{
+    public $my_stdClass;
+    public $my_self;
+    public $my_array;
+    public $my_callable;
+    public $my_bool;
+    public $my_float;
+    public $my_int;
+    public $my_string;
+
+    public function __construct(
+        stdClass $my_stdClass = null,
+        self     $my_self     = null,
+        array    $my_array    = null,
+        callable $my_callable = null,
+        bool     $my_bool     = null,
+        float    $my_float    = null,
+        int      $my_int      = null,
+        string   $my_string   = null
+        /*
+         Add more as they become available in PHP 7.1, 7.2, etc
+         See: http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration
+         */
+    )
+    {
+        $this->my_stdClass = $my_stdClass;
+        $this->my_self     = $my_self;
+        $this->my_array    = $my_array;
+        $this->my_callable = $my_callable;
+        $this->my_bool     = $my_bool;
+        $this->my_float    = $my_float;
+        $this->my_int      = $my_int;
+        $this->my_string   = $my_string;
+    }
+}

--- a/tests/fixtures/INeedParamsWithTypes.php
+++ b/tests/fixtures/INeedParamsWithTypes.php
@@ -3,7 +3,11 @@
 
 class INeedParamsWithTypes
 {
-    public function __construct(stdClass $first_param, string $second_param = 'default')
+    public function __construct(
+        stdClass $first_param, 
+        string $second_param,
+        string $third_param = 'default'
+    )
     {
     }
 }

--- a/tests/fixtures/INeedParamsWithTypes.php
+++ b/tests/fixtures/INeedParamsWithTypes.php
@@ -1,0 +1,9 @@
+<?php
+
+
+class INeedParamsWithTypes
+{
+    public function __construct(stdClass $first_param, string $second_param = 'default')
+    {
+    }
+}

--- a/tests/fixtures/INeedParamsWithTypes.php
+++ b/tests/fixtures/INeedParamsWithTypes.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class INeedParamsWithTypes
 {
     public function __construct(

--- a/tests/fixtures/SubclassOfINeedParamsWithAllTheTypes.php
+++ b/tests/fixtures/SubclassOfINeedParamsWithAllTheTypes.php
@@ -1,0 +1,5 @@
+<?php
+
+class SubclassOfINeedParamsWithAllTheTypes extends INeedParamsWithAllTheTypes
+{
+}


### PR DESCRIPTION
This causes assertion fails if the operational code gives wrong-type data to any parameter